### PR TITLE
Build wheels on manylinux_2_28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,20 +86,16 @@ docs = [
 ]
 
 [tool.cibuildwheel]
-manylinux-x86_64-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
+# qiskit and rustworkx publish only manylinux_2_28 wheels (not manylinux2014), so
+# build/test in that image to pull binary deps instead of compiling sdists.
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 build = "cp310-*"
 skip = "*musllinux* *win32 *i686"
 test-skip = "*win32 *linux_i686"
 test-extras = "test"
 test-command = "pytest {project}/test"
 environment = 'RUSTUP_TOOLCHAIN="stable"'
-
-[tool.cibuildwheel.linux]
-# Latest qiskit dropped manylinux2014 wheels, so pip resolves to the sdist in the
-# test container and needs Rust to build it.
-before-test = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal"
-environment = { RUSTUP_TOOLCHAIN = "stable", PATH = "$HOME/.cargo/bin:$PATH" }
 
 [tool.cibuildwheel.macos]
 environment = "MACOSX_DEPLOYMENT_TARGET='10.12' RUSTUP_TOOLCHAIN=stable"


### PR DESCRIPTION
Build wheels on manylinux_2_28 so we can use rustworkx/qiskit binaries when building wheels