### PR TITLE
Clean up handling of shallow circuits and those with incomplete basis gate sets

### DIFF
--- a/python/qiskit_paulice/_internal/check_picking/__init__.py
+++ b/python/qiskit_paulice/_internal/check_picking/__init__.py
@@ -42,16 +42,24 @@ class CheckedCircuits:
             metric after committing the first ``k`` checks. Length is
             ``len(check_qubits) + 1``. ``None`` if the picker method did not
             report it.
+        committed_targets: The target qubits that actually received a check, in
+            commit order. May be a subsequence of the requested targets when
+            some have no valid check (e.g. too-shallow wires). ``None`` if the
+            picker method did not report it (then all targets are assumed
+            committed).
 
     This class is internal; the public-facing ``CheckedCircuit`` (singular)
     in ``qiskit_paulice.checked_circuit`` is what users see.
     """
 
-    def __init__(self, circuits, check_qubits, virtual_zs, costs=None):
+    def __init__(self, circuits, check_qubits, virtual_zs, costs=None, committed_targets=None):
         self.circuits = circuits
         self.check_qubits = check_qubits
         self.virtual_zs = virtual_zs
         self.costs: list[float] | None = list(costs) if costs is not None else None
+        self.committed_targets: list[int] | None = (
+            list(committed_targets) if committed_targets is not None else None
+        )
 
 
 def pick_checks(
@@ -105,11 +113,13 @@ def pick_checks(
     if verbose:
         print("[CHECK PICKING] Initial metric value:", check_picker.get_current_energy())
     out = method(check_picker, targets, verbose=verbose, seed=seed, **kwargs)
-    # Methods now return `(circuits, check_qubits, virtual_zs, costs)`; tolerate the
-    # older 3-tuple form for backward compatibility.
-    if len(out) == 4:
+    # Methods now return `(circuits, check_qubits, virtual_zs, costs, committed_targets)`;
+    # tolerate the older 4- and 3-tuple forms for backward compatibility.
+    costs = committed_targets = None
+    if len(out) == 5:
+        circuits, check_qubits, virtual_zs, costs, committed_targets = out
+    elif len(out) == 4:
         circuits, check_qubits, virtual_zs, costs = out
     else:
         circuits, check_qubits, virtual_zs = out
-        costs = None
-    return CheckedCircuits(circuits, check_qubits, virtual_zs, costs)
+    return CheckedCircuits(circuits, check_qubits, virtual_zs, costs, committed_targets)

--- a/python/qiskit_paulice/_internal/check_picking/__init__.py
+++ b/python/qiskit_paulice/_internal/check_picking/__init__.py
@@ -40,26 +40,21 @@ class CheckedCircuits:
             Z-basis outcomes XOR together to give that check's syndrome bit.
         costs: Picker-metric values, one per variant; ``costs[k]`` is the
             metric after committing the first ``k`` checks. Length is
-            ``len(check_qubits) + 1``. ``None`` if the picker method did not
-            report it.
+            ``len(check_qubits) + 1``.
         committed_targets: The target qubits that actually received a check, in
             commit order. May be a subsequence of the requested targets when
-            some have no valid check (e.g. too-shallow wires). ``None`` if the
-            picker method did not report it (then all targets are assumed
-            committed).
+            some have no valid check (e.g. too-shallow wires).
 
     This class is internal; the public-facing ``CheckedCircuit`` (singular)
     in ``qiskit_paulice.checked_circuit`` is what users see.
     """
 
-    def __init__(self, circuits, check_qubits, virtual_zs, costs=None, committed_targets=None):
+    def __init__(self, circuits, check_qubits, virtual_zs, costs, committed_targets):
         self.circuits = circuits
         self.check_qubits = check_qubits
         self.virtual_zs = virtual_zs
-        self.costs: list[float] | None = list(costs) if costs is not None else None
-        self.committed_targets: list[int] | None = (
-            list(committed_targets) if committed_targets is not None else None
-        )
+        self.costs: list[float] = list(costs)
+        self.committed_targets: list[int] = list(committed_targets)
 
 
 def pick_checks(
@@ -112,14 +107,7 @@ def pick_checks(
     )
     if verbose:
         print("[CHECK PICKING] Initial metric value:", check_picker.get_current_energy())
-    out = method(check_picker, targets, verbose=verbose, seed=seed, **kwargs)
-    # Methods now return `(circuits, check_qubits, virtual_zs, costs, committed_targets)`;
-    # tolerate the older 4- and 3-tuple forms for backward compatibility.
-    costs = committed_targets = None
-    if len(out) == 5:
-        circuits, check_qubits, virtual_zs, costs, committed_targets = out
-    elif len(out) == 4:
-        circuits, check_qubits, virtual_zs, costs = out
-    else:
-        circuits, check_qubits, virtual_zs = out
+    circuits, check_qubits, virtual_zs, costs, committed_targets = method(
+        check_picker, targets, verbose=verbose, seed=seed, **kwargs
+    )
     return CheckedCircuits(circuits, check_qubits, virtual_zs, costs, committed_targets)

--- a/python/qiskit_paulice/_internal/check_picking/genetic_search.py
+++ b/python/qiskit_paulice/_internal/check_picking/genetic_search.py
@@ -60,6 +60,7 @@ def genetic_algorithm(
     
     circuits = [check_picker.get_circuit()]
     costs = [check_picker.get_current_energy()]
+    committed_targets = []
     for idx, qubit in enumerate(targets):
         if verbose:
             print(
@@ -72,9 +73,10 @@ def genetic_algorithm(
             check_picker, support, verbose, p_mutation, n_stagnant, pop_size
         )
 
+        committed_targets.append(qubit)
         circuits.append(check_picker.get_circuit())
         costs.append(check_picker.get_current_energy())
-    return (circuits, *check_picker.get_check_data(), costs)
+    return (circuits, *check_picker.get_check_data(), costs, committed_targets)
 
 
 def _single_round_genetic(check_picker, support, verbose, p_mutation, n_stagnant, pop_size):
@@ -159,6 +161,7 @@ def windowed_genetic_algorithm(
 
     circuits = [check_picker.get_circuit()]
     costs = [check_picker.get_current_energy()]
+    committed_targets = []
     for idx, qubit in enumerate(targets):
         if verbose:
             print(
@@ -181,11 +184,17 @@ def windowed_genetic_algorithm(
                 )
             picked.append(new_check_picker)
 
+        if not picked:
+            # Support too shallow to form any window; skip rather than crash on min([]).
+            if verbose:
+                print(f"[WGA] No valid check found for target {qubit}; skipping.")
+            continue
         best_check = min(picked, key=lambda x: x.get_current_energy())
         if verbose:
             print(f"[WGA] Best window gave score: {best_check.get_current_energy()}.")
         check_picker = best_check
 
+        committed_targets.append(qubit)
         circuits.append(check_picker.get_circuit())
         costs.append(check_picker.get_current_energy())
-    return (circuits, *check_picker.get_check_data(), costs)
+    return (circuits, *check_picker.get_check_data(), costs, committed_targets)

--- a/python/qiskit_paulice/_internal/check_picking/windowed_search.py
+++ b/python/qiskit_paulice/_internal/check_picking/windowed_search.py
@@ -102,6 +102,7 @@ def windowed_check_picker(
     
     circuits = [check_picker.get_circuit()]
     costs = [check_picker.get_current_energy()]
+    committed_targets = []
     for idx, target in enumerate(targets):
 
         if verbose:
@@ -114,10 +115,18 @@ def windowed_check_picker(
         candidatechecks = _get_good_checks_randomized(
             support, max_width, check_picker, ntries, paulis
         )
+        if not candidatechecks:
+            # No valid check exists for this target (e.g. a wire too shallow to
+            # support one, as on GHZ endpoints). Skip it rather than crashing on
+            # an empty ``min``; the target simply gets no check.
+            if verbose:
+                print(f"[WIN] No valid check found for target {target}; skipping.")
+            continue
         best_check = min(candidatechecks, key=lambda x: x[-1])
         if verbose:
             print(f"[WIN] Best check has score: {best_check[-1]}.")
         check_picker = best_check[0]
+        committed_targets.append(target)
         circuits.append(check_picker.get_circuit())
         costs.append(check_picker.get_current_energy())
-    return (circuits, *check_picker.get_check_data(), costs)
+    return (circuits, *check_picker.get_check_data(), costs, committed_targets)

--- a/python/qiskit_paulice/_internal/simulation.py
+++ b/python/qiskit_paulice/_internal/simulation.py
@@ -42,27 +42,3 @@ def get_gamma(
         virtual_zs,
     )
     return check_picker.get_current_energy()
-
-
-def get_psr_ler(
-    circuit: QuantumCircuit,
-    noise_models: None | list[NoiseModel] = None,
-    stabilizers: None | list[str] | list[Pauli] | str = None,
-    measured_qubits: None | list[int] | str = None,
-    check_qubits: None | list[int] = None,
-    virtual_zs: None | list[list[int]] = None,
-    nshots: None | int = 1000,
-):
-    """Use Monte-Carlo simulation to estimate the post-selection rate and logical error rate
-    """
-    check_picker = build_check_picker(
-        circuit,
-        Metric.gamma(),
-        noise_models,
-        stabilizers,
-        measured_qubits,
-        check_qubits,
-        virtual_zs,
-    )
-    psr, ler = check_picker.estimate_psr_ler(nshots)
-    return psr, ler

--- a/python/qiskit_paulice/_internal/utils.py
+++ b/python/qiskit_paulice/_internal/utils.py
@@ -14,30 +14,12 @@
 """
 
 
-import numpy as np
 from qiskit import QuantumCircuit
 from qiskit.quantum_info import Pauli
 
 from ._internal_r import CheckPicker, NoiseModel
 from ._internal_r import PyMetric as Metric
 from .conversion import convert_to_rustiq_circuit
-
-
-def random_square_circuit(num_qubits: int):
-    """Generates a random squaure LNN circuit"""
-    circuit = QuantumCircuit(num_qubits)
-    circuit.h(range(num_qubits))
-    for d in range(num_qubits):
-        for i in range(d % 2, num_qubits - 1, 2):
-            circuit.cz(i, i + 1)
-        for q in range(num_qubits):
-            if np.random.randint(0, 2):
-                circuit.sx(q)
-            if np.random.randint(0, 2):
-                circuit.s(q)
-            if np.random.randint(0, 2):
-                circuit.sx(q)
-    return circuit
 
 
 def build_check_picker(

--- a/python/qiskit_paulice/checks.py
+++ b/python/qiskit_paulice/checks.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 from typing import Literal, TypeGuard
 
@@ -22,6 +23,7 @@ from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary as _SEL
 from qiskit.quantum_info import Pauli
 from qiskit.transpiler import PassManager
+from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes import BasisTranslator, UnrollCustomDefinitions
 
 from ._internal import Metric as _Metric
@@ -266,37 +268,48 @@ def add_pauli_checks(
         verbose=False,
     )
 
+    # The picker may not place a check on every requested target (e.g. a wire
+    # too shallow to support one); `committed_targets` lists the targets that
+    # actually got a check, in commit order. Checks occupy ancilla slots in that
+    # same order, so the committed ancillas are the first `m` slots after the
+    # payload -- recompute `check_qubits` from that rather than trusting the
+    # station's formula, which assumes every target committed.
+    committed = result.committed_targets
+    if committed is None:
+        committed = list(picker_targets)
+    n_payload_v = virtual_circuit.num_qubits
+    m = len(committed)
+    result.check_qubits = list(range(n_payload_v, n_payload_v + m))
+
     if is_isa:
         # Lift each picker variant onto the input ISA's physical-qubit layout.
+        # Each committed check keeps the ancilla the caller paired with its
+        # target, reordered into commit order.
         anc_list = list(ancilla_qubits)  # type: ignore[arg-type]
+        committed_anc = [anc_list[picker_targets.index(t)] for t in committed]
         result.circuits = [
             _lift_to_isa_circuit(
                 variant=v,
                 qregs=qregs,
                 cregs=cregs,
                 measurement_info=measurement_info,
-                num_payload_virtual=len(payload_phys),
+                num_payload_virtual=n_payload_v,
                 num_active_checks=k,
                 payload_phys=payload_phys,
-                ancilla_qubits=anc_list,
+                ancilla_qubits=committed_anc,
                 check_creg_name=check_creg_name,
             )
             for k, v in enumerate(result.circuits)
         ]
-        # `virtual_zs` and `check_qubits` from the picker reference virtual
-        # indices into the small payload-only circuit. Remap them to the
-        # physical indices used by the lifted output so post-selection reads
-        # the right measurement bits.
-        n_payload_v = len(payload_phys)
+        # `virtual_zs` and `check_qubits` reference virtual indices into the
+        # small payload-only circuit. Remap them to the physical indices used by
+        # the lifted output so post-selection reads the right measurement bits.
         result.virtual_zs = [
-            [payload_phys[q] if q < n_payload_v else anc_list[q - n_payload_v] for q in vzs]
+            [payload_phys[q] if q < n_payload_v else committed_anc[q - n_payload_v] for q in vzs]
             for vzs in result.virtual_zs
         ]
-        result.check_qubits = [
-            anc_list[q - n_payload_v] if q >= n_payload_v else payload_phys[q]
-            for q in result.check_qubits
-        ]
-        target_qubits_out = [payload_phys[t] for t in picker_targets]
+        result.check_qubits = list(committed_anc)
+        target_qubits_out = [payload_phys[t] for t in committed]
     else:
         # Restore original measurements and add check measurements (non-ISA path).
         _restore_measurements_and_cregs(
@@ -309,7 +322,7 @@ def add_pauli_checks(
             check_creg_name=check_creg_name,
             check_qreg_name=check_qreg_name,
         )
-        target_qubits_out = list(target_qubits)
+        target_qubits_out = list(committed)
 
     # Re-express every output in the input circuit's basis. The picker emits its
     # internal Clifford basis ({h, cx, cz, s, sx, sdg, sxdg}); translate back so
@@ -379,7 +392,19 @@ def _translate_to_basis(circuit: QuantumCircuit, basis_gates: list[str]) -> Quan
             BasisTranslator(_SEL, basis_gates),
         ]
     )
-    return pm.run(circuit)
+    try:
+        return pm.run(circuit)
+    except TranspilerError:
+        # The input basis can't express the checks the picker inserted -- it is
+        # not universal (e.g. {h, cx}, with no phase gate, as for a virtual GHZ).
+        # Leave the circuit in the package's internal Clifford basis.
+        warnings.warn(
+            f"Could not re-express the output in the input gate set {sorted(basis_gates)}; "
+            "it is not universal for the inserted checks. Returning the circuit in the "
+            "internal Clifford basis instead.",
+            stacklevel=2,
+        )
+        return circuit
 
 
 def _strip_measurements_cregs_barriers(circuit: QuantumCircuit):

--- a/python/qiskit_paulice/checks.py
+++ b/python/qiskit_paulice/checks.py
@@ -275,8 +275,6 @@ def add_pauli_checks(
     # payload -- recompute `check_qubits` from that rather than trusting the
     # station's formula, which assumes every target committed.
     committed = result.committed_targets
-    if committed is None:
-        committed = list(picker_targets)
     n_payload_v = virtual_circuit.num_qubits
     m = len(committed)
     result.check_qubits = list(range(n_payload_v, n_payload_v + m))
@@ -331,7 +329,7 @@ def add_pauli_checks(
 
     # Build the public per-variant list. `result.costs[k]` is the picker metric
     # after committing the first `k` checks.
-    costs = result.costs if result.costs is not None else [None] * len(result.circuits)
+    costs = result.costs
     target_qubits_tuple = tuple(target_qubits_out)
     check_qubits_tuple = tuple(result.check_qubits)
     check_support_tuple = tuple(tuple(s) for s in result.virtual_zs)

--- a/releasenotes/notes/incomp-basis-7b2b6217476924f9.yaml
+++ b/releasenotes/notes/incomp-basis-7b2b6217476924f9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed issue where input circuits defined on an incomplete Clifford basis gate set would fail to transform back into their original basis after check picking. Now, instead of failing, the checked circuit will be returned in the internal Clifford basis.

--- a/releasenotes/notes/shallow-fixes-831441881ad1dafc.yaml
+++ b/releasenotes/notes/shallow-fixes-831441881ad1dafc.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed issues with circuits containing wires with 2-qubit-depth of 1.

--- a/src/check_evaluator.rs
+++ b/src/check_evaluator.rs
@@ -74,15 +74,6 @@ impl CheckEvaluator {
             Metric::BalancedGamma => coverage.balanced_gamma_apx(),
         }
     }
-    /// Shorthand to call the error-based Monte-Carlo simulation
-    pub fn get_psr_ler(&self, nshots: usize) -> (f64, f64) {
-        let all_check_qubits = self.current_checks.clone();
-        let all_virtual_zs = self.current_virtual_zs.clone();
-        let mut coverage = Coverage::new(&self.base_circuit, &self.noise_models);
-        coverage.set_check_cumulants(&all_check_qubits, &all_virtual_zs);
-        coverage.set_logical_cumulants(&self.stabilizers, &self.measured_qubits);
-        coverage.approximate_psr_ler(nshots)
-    }
     /// Utility method to infer the virtual Zs for a given check.
     /// Also checks that the check ends up diagonal when pulled to the end.
     pub fn compute_vzs(&self, check: &SparsePauli) -> Vec<usize> {

--- a/src/check_picker.rs
+++ b/src/check_picker.rs
@@ -114,12 +114,6 @@ impl CheckPicker {
             .collect()
     }
 
-    /// Estimates the post-selection rate and logical error rate via Monte-Carlo simulation
-    /// - nshots: number of shots to use in the estimation
-    pub fn estimate_psr_ler(&self, nshots: usize) -> (f64, f64) {
-        self.check_evaluator.as_ref().unwrap().get_psr_ler(nshots)
-    }
-
     /// Sets all the data required to evaluate check's performances
     /// - Noise models: a list of noise models
     /// - Metric: the metric used to evaluate the performance of the check

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import unittest
+import warnings
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, transpile
 from qiskit.quantum_info import PauliLindbladMap
@@ -23,6 +24,7 @@ from qiskit_paulice import CheckedCircuit
 from qiskit_paulice.checks import (
     _lift_to_isa_circuit,
     _remove_inactive_qubits,
+    _translate_to_basis,
     add_pauli_checks,
 )
 from qiskit_paulice.noise_models import NoiseModel
@@ -41,6 +43,16 @@ def _clifford(nq: int = 3, layers: int = 2) -> QuantumCircuit:
         qc.cx(1, 2)
         qc.s(0)
         qc.s(2)
+    qc.measure_all()
+    return qc
+
+
+def _ghz(n: int) -> QuantumCircuit:
+    """An n-qubit GHZ circuit (shallow per-qubit wires) with terminal measurements."""
+    qc = QuantumCircuit(n)
+    qc.h(0)
+    for i in range(n - 1):
+        qc.cx(i, i + 1)
     qc.measure_all()
     return qc
 
@@ -107,6 +119,64 @@ class TestAddPauliChecksOutputBasis(unittest.TestCase):
         )
         for variant in result:
             self.assertLessEqual(_gate_names(variant.circuit), basis)
+
+    def test_non_universal_input_basis_falls_back(self):
+        # {h, cx} is not universal (no phase gate), so the picker's Clifford
+        # output (e.g. an sx) cannot be re-expressed in it. Rather than raising a
+        # TranspilerError, the circuit is returned untouched with a warning.
+        qc = QuantumCircuit(1)
+        qc.sx(0)
+        with self.assertWarns(UserWarning):
+            out = _translate_to_basis(qc, ["h", "cx"])
+        self.assertEqual(_gate_names(out), {"sx"})
+
+
+class TestAddPauliChecksShallowWires(unittest.TestCase):
+    """GHZ circuits stress the picker: per-qubit wires are very shallow."""
+
+    def test_ghz_skips_unprotectable_targets(self):
+        # GHZ endpoint wires are too shallow to host a check, so those targets
+        # are skipped instead of crashing the picker (regression: the windowed
+        # search used to raise "min() arg is an empty sequence"). Interior qubits
+        # are checkable. The reported targets/checks reflect only what committed.
+        n = 6
+        with warnings.catch_warnings():
+            # GHZ's {h, cx} basis is non-universal; the basis-match step may warn.
+            warnings.simplefilter("ignore", UserWarning)
+            result = add_pauli_checks(_ghz(n), list(range(n)), _DEFAULT_NOISE, seed=0)
+        final = result[-1]
+        self.assertEqual(final.target_qubits, tuple(range(1, n - 1)))  # endpoints dropped
+        self.assertEqual(len(final.check_qubits), len(final.target_qubits))
+        self.assertEqual(len(final.check_support), len(final.target_qubits))
+        _assert_variant_progression(self, result, expected_targets=list(range(1, n - 1)))
+
+    def test_ghz_endpoint_only_target_yields_no_checks(self):
+        # A lone endpoint target can't be checked: return just the bare circuit.
+        result = add_pauli_checks(_ghz(4), [0], _DEFAULT_NOISE, seed=0)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].target_qubits, ())
+        self.assertEqual(result[0].check_qubits, ())
+
+    def test_ghz_checks_are_valid_noiselessly(self):
+        # Correctness: with no noise every shot must pass all checks (syndrome 0)
+        # and the payload must stay a clean GHZ distribution -- this validates the
+        # check-qubit / syndrome mapping for the skipped-target case.
+        from qiskit_aer import AerSimulator
+
+        n = 5
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            final = add_pauli_checks(_ghz(n), list(range(n)), _DEFAULT_NOISE, seed=0)[-1]
+        counts = (
+            AerSimulator(method="stabilizer")
+            .run(final.circuit, shots=2000, seed_simulator=1)
+            .result()
+            .get_counts()
+        )
+        postselect = final.get_postselection_method()
+        self.assertTrue(all(not postselect(bitstring).any() for bitstring in counts))
+        payloads = {bitstring.split()[-1] for bitstring in counts}
+        self.assertLessEqual(payloads, {"0" * n, "1" * n})
 
 
 class TestAddPauliChecksBasic(unittest.TestCase):


### PR DESCRIPTION
Skip depth-1 wires in windowed search, rather than erroring out.

If the input circuit gates do not form a complete Clifford basis, we can't translate the checks back into the original basis after check picking. Rather than erroring, just return the circuit defined on the internal basis gate set.