### PR TITLE
Box checked circuit

### DIFF
--- a/docs/apidocs/qiskit_paulice.checked_circuit.rst
+++ b/docs/apidocs/qiskit_paulice.checked_circuit.rst
@@ -12,3 +12,4 @@ Checked circuit (:mod:`qiskit_paulice.checked_circuit`)
 .. autoclass:: CheckedCircuit
 .. autoclass:: UncoveredPauli
    :exclude-members: qubit, after_instruction, pauli
+.. autodata:: BOXING_DEFAULTS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "qiskit>=2.1.2, <3",
     "numpy>=1.26",
     "qiskit-aer>=0.17.1",
+    "samplomatic>=0.20.0",
 ]
 
 [tool.maturin]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 requires-python = ">=3.10"
 
 dependencies = [
-    "qiskit>=2.1.2, <3",
+    "qiskit>=2.3, <3",
     "numpy>=1.26",
     "qiskit-aer>=0.17.1",
     "samplomatic>=0.20.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ notebook-dependencies = [
     "qiskit-paulice",
     "matplotlib",
     "qiskit-ibm-runtime",
-    "rustworkx[graphviz]>=0.15",
+    "rustworkx[graphviz]>=0.16",
     "ipywidgets",
     "pylatexenc",
 ]

--- a/python/qiskit_paulice/checked_circuit.py
+++ b/python/qiskit_paulice/checked_circuit.py
@@ -193,7 +193,8 @@ class CheckedCircuit:
         Args:
             payload_layers: The unique entangling layers of the bare payload circuit. Each inner
                 list contains the edges for one unique layer. Edges should not be repeated
-                within the same layer nor across layers.
+                within the same layer, but may appear in multiple layers; each stratum of the
+                boxed circuit is then consistent with (a subset of) one of these layers.
             **kwargs: Overrides for :func:`~samplomatic.transpiler.generate_boxing_pass_manager`.
                 Defaults to the key-value pairs in
                 :data:`~qiskit_paulice.checked_circuit.BOXING_DEFAULTS`.
@@ -203,7 +204,6 @@ class CheckedCircuit:
 
         Raises:
             ValueError: ``payload_layers`` does not describe this circuit's payload gates.
-            ValueError: ``payload_layers`` contains duplicate edges.
             ValueError: :attr:`circuit` contains an instruction other than one- and two-qubit
                 unitary gates, measurements, and barriers.
         """
@@ -255,10 +255,11 @@ class CheckedCircuit:
         indices = [[circuit.find_bit(q).index for q in inst.qubits] for inst in data]
 
         # Get a mapping from edges to their associated layer IDs
-        edge_to_layer = _edge_to_layer(payload_layers) if payload_layers is not None else None
+        edge_to_layers = _edge_to_layers(payload_layers) if payload_layers is not None else None
 
-        # For a given layer of entangling gates (stratum), store which unique layer it is.
-        stratum_ids: list[int] = []
+        # For a given layer of entangling gates (stratum), store which unique layers it is
+        # still consistent with; joining gates narrow the set.
+        viable_layers: list[set[int]] = []
         # Mapping from a gap between two payload layers to the number of checks it contains
         checks_in_gap: dict[int, int] = defaultdict(int)
         # Mapping from qubit ID to the earliest stratum ID where it is free
@@ -280,19 +281,21 @@ class CheckedCircuit:
                 continue
             # Earliest stratum where both qubits are free: ASAP packing.
             layer = max(free_from[a], free_from[b])
-            if edge_to_layer is not None:
-                if (a, b) not in edge_to_layer:
+            if edge_to_layers is not None:
+                if (a, b) not in edge_to_layers:
                     raise ValueError(
                         "payload_layers does not describe this circuit's payload gates: edge "
                         f"{(a, b)} is in no layer."
                     )
-                unique = edge_to_layer[(a, b)]
-                # Skip past strata that are instances of a different unique layer.
-                while layer < len(stratum_ids) and stratum_ids[layer] != unique:
+                candidates = edge_to_layers[(a, b)]
+                # Skip past strata consistent with none of the layers containing this edge.
+                while layer < len(viable_layers) and not viable_layers[layer] & candidates:
                     layer += 1
-                # Start a new stratum if necessary
-                if layer == len(stratum_ids):
-                    stratum_ids.append(unique)
+                # Start a new stratum if necessary, else narrow the joined stratum's layers
+                if layer == len(viable_layers):
+                    viable_layers.append(set(candidates))
+                else:
+                    viable_layers[layer] &= candidates
             # Specify the stratum the payload instruction is associated with and hard-code 0 to indicate this is a payload stratum.
             keys[i] = (layer, 0)
             # Both qubits are now occupied through this stratum.
@@ -322,14 +325,12 @@ class CheckedCircuit:
         return out
 
 
-def _edge_to_layer(
+def _edge_to_layers(
     payload_layers: Iterable[Iterable[tuple[int, int]]],
-) -> dict[tuple[int, int], int]:
-    """Map each entangling edge to the index of the unique payload layer containing it."""
-    edge_to_layer: dict[tuple[int, int], int] = {}
+) -> dict[tuple[int, int], set[int]]:
+    """Map each entangling edge to the indices of the unique payload layers containing it."""
+    edge_to_layers: dict[tuple[int, int], set[int]] = defaultdict(set)
     for index, layer in enumerate(payload_layers):
         for a, b in layer:
-            edge = (min(a, b), max(a, b))
-            if edge_to_layer.setdefault(edge, index) != index:
-                raise ValueError(f"edge {edge} appears in more than one payload layer.")
-    return edge_to_layer
+            edge_to_layers[(min(a, b), max(a, b))].add(index)
+    return dict(edge_to_layers)

--- a/python/qiskit_paulice/checked_circuit.py
+++ b/python/qiskit_paulice/checked_circuit.py
@@ -23,14 +23,17 @@ from typing import Any, Literal, NamedTuple
 
 import numpy as np
 from qiskit import QuantumCircuit
+from qiskit.circuit import Gate
 from samplomatic.transpiler import generate_boxing_pass_manager
 
 from ._internal import Metric as _Metric
 from ._internal.conversion import convert_to_rustiq_circuit as _convert_to_rustiq_circuit
 from ._internal.utils import build_check_picker as _build_check_picker
 
-_NOT_PROPAGATED = frozenset({"measure", "barrier", "delay"})
-_BOXING_DEFAULTS: dict[str, Any] = {
+# Non-unitary instructions :meth:`CheckedCircuit.box` accepts; all else is rejected.
+_NON_GATES = frozenset({"measure", "barrier"})
+
+BOXING_DEFAULTS: dict[str, Any] = {
     "twirling_strategy": "active",
     "inject_noise_strategy": "individual_modification",
     "inject_noise_targets": "gates",
@@ -38,10 +41,12 @@ _BOXING_DEFAULTS: dict[str, Any] = {
     "measure_annotations": "all",
     "remove_barriers": "after_stratification",
 }
+"""Options :meth:`CheckedCircuit.box` passes to
+:func:`~samplomatic.transpiler.generate_boxing_pass_manager`, before ``**kwargs`` overrides."""
 
 
 class UncoveredPauli(NamedTuple):
-    """A spacetime location at which a single qubit Pauli error is undetectable by a set of checks.
+    """A spacetime location at which a single qubit Pauli error is undetectable by the set of checks.
 
     Attributes:
         qubit: Index of the qubit where the undetected error sits
@@ -130,25 +135,6 @@ class CheckedCircuit:
                 )
         return tuple(out)
 
-    @cached_property
-    def _cb_to_q(self) -> dict[int, int]:
-        cb_to_q: dict[int, int] = {}
-        for inst in self.circuit.data:
-            if inst.operation.name == "measure":
-                q = self.circuit.find_bit(inst.qubits[0]).index
-                cb = self.circuit.find_bit(inst.clbits[0]).index
-                cb_to_q[cb] = q
-        return cb_to_q
-
-    @cached_property
-    def _sub_array(self) -> np.ndarray:
-        n_qubits_full = self.circuit.num_qubits
-        sub_array = np.zeros((len(self.check_support), n_qubits_full), dtype=np.byte)
-        for i, vzs in enumerate(self.check_support):
-            for q in vzs:
-                sub_array[i, q] = 1
-        return sub_array
-
     def get_postselection_method(self) -> Callable[[str | np.ndarray], np.ndarray]:
         """Return a function that maps a single shot's outcome to a syndrome vector.
 
@@ -193,78 +179,101 @@ class CheckedCircuit:
         payload_layers: Iterable[Iterable[tuple[int, int]]] | None = None,
         **kwargs,
     ) -> QuantumCircuit:
-        """Box :attr:`circuit` for samplomatic, with every check gate isolated in its own layer.
+        """Box :attr:`circuit` while maintaining concurrent scheduling of payload layers.
 
-        Runs :func:`~samplomatic.transpiler.generate_boxing_pass_manager` on :attr:`circuit` --
-        the circuit that is actually executed, ancillas and check gates included -- after
-        regrouping it so each check gate sits alone in a two-qubit layer scoped to its own
-        qubits. Repeats of a box with the same entangling gates then share a ``ref``: the unique
-        layers a noise learner must characterize are the payload's own plus one small layer per
-        check, a count that does not grow with circuit depth, and the payload boxes carry the
-        same ``ref`` values as a boxing of the bare circuit, so a noise model learned once on the
-        bare circuit binds to them.
-
-        Box the executed circuit, never the bare one: the bare circuit's boxes carry different
-        ``ref`` values while their ``modifier_ref`` values collide with this circuit's. For a
-        depth-preserving boxing without check isolation, run samplomatic's boxing pass on
-        :attr:`circuit` directly.
+        This method schedules each entangling gate connecting a target, ancilla pair of
+        qubits into its own box. This is beneficial in that the number of unique entangling
+        layers is minimized, but it comes at a cost of sub-optimal scheduling since scheduling
+        each gate of each Pauli check into its own time slice causes additional idling time across
+        all qubits.
 
         Args:
-            payload_layers: the payload's unique entangling layers, each a collection of
-                qubit-index pairs. Supply them when the payload's layer structure is known; every
-                payload stratum is then an instance of exactly one of these layers. An edge may
-                appear in only one layer. When ``None``, layers are derived by packing payload
-                gates as early as possible, which may not recover an intended structure.
-            **kwargs: overrides for :func:`~samplomatic.transpiler.generate_boxing_pass_manager`.
+            payload_layers: The unique entangling layers of the bare payload circuit. Each inner
+                list contains the edges for one unique layer. Edges should not be repeated
+                within the same layer nor across layers.
+            **kwargs: Overrides for :func:`~samplomatic.transpiler.generate_boxing_pass_manager`.
+                Defaults to the key-value pairs in
+                :data:`~qiskit_paulice.checked_circuit.BOXING_DEFAULTS`.
 
         Returns:
             :attr:`circuit`, boxed and annotated.
 
         Raises:
-            ValueError: ``payload_layers`` does not describe this circuit's payload gates, or
-                :attr:`circuit` contains a reset, which is not yet supported.
+            ValueError: ``payload_layers`` does not describe this circuit's payload gates.
+            ValueError: ``payload_layers`` contains duplicate edges.
+            ValueError: :attr:`circuit` contains an instruction other than unitary gates,
+                measurements, and barriers.
         """
-        if any(instruction.operation.name == "reset" for instruction in self.circuit.data):
-            raise ValueError(
-                "circuits containing resets are not supported yet: propagating check "
-                "operators through a reset is not implemented."
-            )
-        options = {**_BOXING_DEFAULTS, **kwargs}
+        for instruction in self.circuit.data:
+            operation = instruction.operation
+            if not isinstance(operation, Gate) and operation.name not in _NON_GATES:
+                raise ValueError(
+                    f"'{operation.name}' is not supported: a checked circuit may contain only "
+                    "unitary gates, measurements, and barriers."
+                )
+        options = {**BOXING_DEFAULTS, **kwargs}
         return generate_boxing_pass_manager(**options).run(self._stratify(payload_layers))
+
+    @cached_property
+    def _cb_to_q(self) -> dict[int, int]:
+        cb_to_q: dict[int, int] = {}
+        for inst in self.circuit.data:
+            if inst.operation.name == "measure":
+                q = self.circuit.find_bit(inst.qubits[0]).index
+                cb = self.circuit.find_bit(inst.clbits[0]).index
+                cb_to_q[cb] = q
+        return cb_to_q
+
+    @cached_property
+    def _sub_array(self) -> np.ndarray:
+        n_qubits_full = self.circuit.num_qubits
+        sub_array = np.zeros((len(self.check_support), n_qubits_full), dtype=np.byte)
+        for i, vzs in enumerate(self.check_support):
+            for q in vzs:
+                sub_array[i, q] = 1
+        return sub_array
 
     def _stratify(
         self, payload_layers: Iterable[Iterable[tuple[int, int]]] | None
     ) -> QuantumCircuit:
-        """Re-emit :attr:`circuit` with each check gate alone in its own barrier-delimited layer.
+        """Return a copy of the checked circuit that is separated into layers.
 
-        Every instruction gets a stratum key and the circuit is stable-sorted by it. The keys are
-        monotone along every qubit's wire, so no two instructions sharing a qubit are ever
-        reordered and the result implements the same unitary.
+        This method isolates entangling gates that are part of a Pauli check into
+        their own stratum and maintains the payload layer scheduling. This has the
+        downside of additional idling time on all qubits and the upside of having
+        fewer unique entangling layers for which to learn noise.
         """
+        # Unpack circuit into lists of instructions and qubit indices
         circuit = self.circuit
         ancillas = set(self.check_qubits)
         data = [inst for inst in circuit.data if inst.operation.name != "barrier"]
         indices = [[circuit.find_bit(q).index for q in inst.qubits] for inst in data]
 
+        # Get a mapping from edges to their associated layer IDs
         edge_to_layer = _edge_to_layer(payload_layers) if payload_layers is not None else None
+
+        # For a given layer of entangling gates (stratum), store which unique layer it is.
         stratum_ids: list[int] = []
-        after_layer: dict[int, int] = defaultdict(lambda: -1)
+        # Mapping from a gap between two payload layers to the number of checks it contains
         checks_in_gap: dict[int, int] = defaultdict(int)
+        # Mapping from qubit ID to the earliest stratum ID where it is free
         free_from: dict[int, int] = defaultdict(int)
 
-        # Payload gates pack as early as their qubits allow; each check gate gets a stratum of
-        # its own, in the gap after the last payload layer to touch its target.
-        keys: dict[int, tuple[int, int, int]] = {}
+        # Mapping from entangling gates to the gap/stratum in which they belong
+        keys: dict[int, tuple[int, int]] = {}
         for i, inst in enumerate(data):
-            if len(inst.qubits) != 2 or inst.operation.name in _NOT_PROPAGATED:
+            if len(inst.qubits) != 2:
                 continue
             a, b = sorted(indices[i])
+            # Instruction is a check gate
             if {a, b} & ancillas:
                 target = b if a in ancillas else a
-                gap = after_layer[target]
+                # Check qubit should be sandwiched between payload strata where its target qubit is used
+                gap = free_from[target] - 1
                 checks_in_gap[gap] += 1
-                keys[i] = (gap, 1, checks_in_gap[gap])
+                keys[i] = (gap, checks_in_gap[gap])
                 continue
+            # Earliest stratum where both qubits are free: ASAP packing.
             layer = max(free_from[a], free_from[b])
             if edge_to_layer is not None:
                 if (a, b) not in edge_to_layer:
@@ -272,19 +281,22 @@ class CheckedCircuit:
                         "payload_layers does not describe this circuit's payload gates: edge "
                         f"{(a, b)} is in no layer."
                     )
-                # Never mix gates from different unique layers in one stratum.
                 unique = edge_to_layer[(a, b)]
+                # Skip past strata that are instances of a different unique layer.
                 while layer < len(stratum_ids) and stratum_ids[layer] != unique:
                     layer += 1
+                # Start a new stratum if necessary
                 if layer == len(stratum_ids):
                     stratum_ids.append(unique)
-            keys[i] = (layer, 0, 0)
-            free_from[a] = free_from[b] = layer + 1
-            after_layer[a] = after_layer[b] = layer
+            # Specify the stratum the payload instruction is associated with and hard-code 0 to indicate this is a payload stratum.
+            keys[i] = (layer, 0)
+            # Both qubits are now occupied through this stratum.
+            free_from[a] = layer + 1
+            free_from[b] = layer + 1
 
-        # Every other instruction rides with the next entangler on any of its qubits, or the end.
-        end = (len(data), 0, 0)
-        next_key: dict[int, tuple[int, int, int]] = defaultdict(lambda: end)
+        # Associate single qubit gates with the entangling stratum to their right
+        end = (len(data), 0)
+        next_key: dict[int, tuple[int, int]] = defaultdict(lambda: end)
         for i in reversed(range(len(data))):
             if i in keys:
                 for q in indices[i]:
@@ -293,11 +305,14 @@ class CheckedCircuit:
                 keys[i] = min((next_key[q] for q in indices[i]), default=end)
 
         out = circuit.copy_empty_like()
+        # Reorder the instructions by which stratum they're in. Original order maintained in ties.
+        # Place instructions in new order such that original unique layers are maintained and
+        # Pauli check gates have their own time-slice. Use barriers to delimit the strata.
         order = sorted(range(len(data)), key=keys.__getitem__)
-        for key, stratum in groupby(order, key=keys.__getitem__):
-            for i in stratum:
+        for stratum_key, members in groupby(order, key=keys.__getitem__):
+            for i in members:
                 out.append(data[i])
-            if key != end:
+            if stratum_key != end:
                 out.barrier()
         return out
 

--- a/python/qiskit_paulice/checked_circuit.py
+++ b/python/qiskit_paulice/checked_circuit.py
@@ -67,7 +67,7 @@ class CheckedCircuit:
     Attributes:
         circuit: A quantum circuit containing ``0`` or more spacetime Pauli checks.
         target_qubits: Qubit indices of ``circuit`` which were used to entangle the check
-            qubits to the payload. ``None`` if ``circuit`` contains no checks.
+            qubits to the payload. Empty if ``circuit`` contains no checks.
         check_qubits: Qubit indices of the ancilla qubits in ``circuit``. The ``i``th
             check uses ``check_qubits[i]`` to detect errors on ``target_qubits[i]`` and other
             qubits in ``check_support[i]``.
@@ -201,15 +201,17 @@ class CheckedCircuit:
         Raises:
             ValueError: ``payload_layers`` does not describe this circuit's payload gates.
             ValueError: ``payload_layers`` contains duplicate edges.
-            ValueError: :attr:`circuit` contains an instruction other than unitary gates,
-                measurements, and barriers.
+            ValueError: :attr:`circuit` contains an instruction other than one- and two-qubit
+                unitary gates, measurements, and barriers.
         """
         for instruction in self.circuit.data:
             operation = instruction.operation
-            if not isinstance(operation, Gate) and operation.name not in _NON_GATES:
+            if operation.name in _NON_GATES:
+                continue
+            if not isinstance(operation, Gate) or len(instruction.qubits) > 2:
                 raise ValueError(
                     f"'{operation.name}' is not supported: a checked circuit may contain only "
-                    "unitary gates, measurements, and barriers."
+                    "one- and two-qubit unitary gates, measurements, and barriers."
                 )
         options = {**BOXING_DEFAULTS, **kwargs}
         return generate_boxing_pass_manager(**options).run(self._stratify(payload_layers))

--- a/python/qiskit_paulice/checked_circuit.py
+++ b/python/qiskit_paulice/checked_circuit.py
@@ -14,17 +14,45 @@
 
 from __future__ import annotations
 
+from collections import Counter, defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Literal, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 import numpy as np
 from qiskit import QuantumCircuit
+from samplomatic.transpiler import generate_boxing_pass_manager
 
 from ._internal import Metric as _Metric
 from ._internal.conversion import convert_to_rustiq_circuit as _convert_to_rustiq_circuit
 from ._internal.utils import build_check_picker as _build_check_picker
+
+# Instructions to ignore during Pauli evolution. Resets are deliberately absent: they do affect
+# the Heisenberg evolution, and are rejected until supported.
+_NOT_PROPAGATED = frozenset({"measure", "barrier", "delay"})
+
+# Boxing options used by :meth:`CheckedCircuit.box`. ``individual_modification`` is what gives
+# every box its own ``modifier_ref``, which is what makes per-box ``local_scales`` possible.
+# ``inject_noise_site`` is pinned rather than left to samplomatic's default, which is currently
+# ``"before"`` but is slated to become ``"after"``: a layer's learned noise describes what that
+# layer does, so it belongs after the layer.
+_BOXING_DEFAULTS: dict[str, Any] = {
+    "twirling_strategy": "active_circuit",
+    "inject_noise_strategy": "individual_modification",
+    "inject_noise_targets": "gates",
+    "inject_noise_site": "after",
+    "measure_annotations": "all",
+}
+
+# Extra options for ``check_layers="isolated"``. ``active`` scopes each box to the qubits it acts
+# on, which is what lets the payload boxes carry the same ``ref`` and generators as the bare
+# circuit's -- under ``active_circuit`` they would also span the ancillas and diverge. The barriers
+# `_stratify` emits are what the boxing pass stratifies on, so they must survive until it runs.
+_ISOLATED_BOXING_DEFAULTS: dict[str, Any] = {
+    "twirling_strategy": "active",
+    "remove_barriers": "after_stratification",
+}
 
 
 class UncoveredPauli(NamedTuple):
@@ -174,3 +202,229 @@ class CheckedCircuit:
             return (sub_array @ x) % 2
 
         return _aux
+
+    def box(
+        self,
+        *,
+        check_layers: Literal["merged", "isolated"] = "isolated",
+        payload_layers: QuantumCircuit | None = None,
+        **kwargs,
+    ) -> QuantumCircuit:
+        """Group this checked circuit into annotated boxes, ready for noise learning and sampling.
+
+        Runs :func:`~samplomatic.transpiler.generate_boxing_pass_manager` on :attr:`circuit` --
+        that is, on the circuit that is actually executed, ancillas and check gates included. The
+        boxes it produces are the layers whose noise a learner characterizes and the layers a
+        :class:`~samplomatic.samplex.Samplex` injects noise into, so the stages agree by
+        construction.
+
+        Boxing the *bare* circuit instead is a silent error: check insertion changes which gates
+        share a layer, so the bare circuit's layers carry different ``ref`` values (a noise model
+        learned for them cannot be bound) while its ``modifier_ref`` values collide with this
+        circuit's (so ``local_scales`` derived from it may bind to the wrong layers).
+
+        Args:
+            check_layers: how to lay out the check gates. Each value is a coherent configuration,
+                not an independent knob -- ``"isolated"`` also scopes each box to the qubits it
+                acts on (``twirling_strategy="active"``), because that is what makes the payload
+                boxes match the bare circuit's. Override either via ``**kwargs`` if you need to.
+
+                - ``"merged"``: let the boxing pass pack check gates into whichever payload layer
+                  has room, and twirl every active qubit in every box. Leaves the circuit's depth
+                  alone and models idling noise everywhere, but each layer ends up holding a
+                  different subset of the ancilla edges, so almost every layer is unique and the
+                  number of layers to learn grows with circuit depth.
+                - ``"isolated"`` (the default): give every check gate a layer of its own, and
+                  scope each box to its own qubits. A one-gate box has the same content every time that check fires,
+                  so the layers to learn become the payload's own plus one small two-qubit layer
+                  per check -- a count that does not grow with depth. Crucially the payload boxes
+                  now carry the same ``ref`` and the same generators as the *bare* circuit's, so a
+                  noise model learned once on the bare circuit binds to them, and keeps binding as
+                  the checks change. The costs are real: roughly two to three times the boxes, so a
+                  deeper circuit carrying more idling noise, and idling on qubits a box does not
+                  touch is neither twirled nor modelled.
+
+            payload_layers: a circuit whose barriers (or boxes) mark the payload's intended layer
+                boundaries, used only when ``check_layers="isolated"``. Supply the bare circuit
+                the checks were added to when its layer structure is known; its payload layers are
+                then reproduced exactly. When ``None``, layers are derived by packing payload gates
+                as early as possible, which may not recover an intended structure -- a layering
+                that leaves gaps gets repacked into more distinct layers than it started with.
+            **kwargs: overrides for :func:`~samplomatic.transpiler.generate_boxing_pass_manager`.
+                Defaults are ``twirling_strategy="active_circuit"``,
+                ``inject_noise_strategy="individual_modification"``,
+                ``inject_noise_targets="gates"``, ``inject_noise_site="after"`` and
+                ``measure_annotations="all"``.
+
+        Returns:
+            :attr:`circuit`, boxed and annotated.
+
+        Raises:
+            ValueError: ``check_layers`` is not ``"merged"`` or ``"isolated"``,
+                ``payload_layers`` does not describe this circuit's payload gates, or
+                :attr:`circuit` contains a reset, which is not yet supported.
+        """
+        if any(instruction.operation.name == "reset" for instruction in self.circuit.data):
+            raise ValueError(
+                "circuits containing resets are not supported yet: propagating check "
+                "operators through a reset is not implemented."
+            )
+        if check_layers == "merged":
+            return generate_boxing_pass_manager(**{**_BOXING_DEFAULTS, **kwargs}).run(self.circuit)
+        if check_layers != "isolated":
+            raise ValueError(f"check_layers must be 'merged' or 'isolated', got {check_layers!r}.")
+        options = {
+            **_BOXING_DEFAULTS,
+            **_ISOLATED_BOXING_DEFAULTS,
+            **kwargs,
+        }
+        return generate_boxing_pass_manager(**options).run(self._stratify(payload_layers))
+
+    def _stratify(self, payload_layers: QuantumCircuit | None) -> QuantumCircuit:
+        """Re-emit :attr:`circuit` with each check gate alone in its own barrier-delimited layer.
+
+        Gates are only regrouped, never added, removed, or reordered relative to any qubit they
+        share, so the result implements the same unitary.
+        """
+        circuit = self.circuit
+        ancillas = set(self.check_qubits)
+        data = list(circuit.data)
+        indices = {i: [circuit.find_bit(q).index for q in data[i].qubits] for i in range(len(data))}
+        entanglers = [
+            i
+            for i in range(len(data))
+            if len(data[i].qubits) == 2 and data[i].operation.name not in _NOT_PROPAGATED
+        ]
+
+        layer_map = _payload_layer_map(payload_layers) if payload_layers is not None else None
+        payload_layer: dict[int, int] = {}
+        gaps: dict[int, list[int]] = defaultdict(list)
+        after_layer: dict[int, int] = defaultdict(lambda: -1)
+        occurrence: Counter = Counter()
+        free_from: dict[int, int] = defaultdict(int)
+
+        for i in entanglers:
+            a, b = sorted(indices[i])
+            if {a, b} & ancillas:
+                # A check gate sits in the gap after the last payload layer to touch its target.
+                target = b if a in ancillas else a
+                gaps[after_layer[target]].append(i)
+                continue
+            if layer_map is None:
+                # No authored layering to honour: pack as early as the qubits allow.
+                layer = max(free_from[a], free_from[b])
+            else:
+                key = ((a, b), occurrence[(a, b)])
+                if key not in layer_map:
+                    raise ValueError(
+                        "payload_layers does not describe this circuit's payload gates: no layer "
+                        f"for occurrence {key[1]} of edge {key[0]}. It must contain the same "
+                        "entangling gates as the bare circuit these checks were added to."
+                    )
+                layer = layer_map[key]
+                if layer < max(free_from[a], free_from[b]):
+                    raise ValueError(
+                        f"payload_layers orders edge {(a, b)} inconsistently with this circuit: "
+                        f"layer {layer} follows a gate already placed at or after it."
+                    )
+            occurrence[(a, b)] += 1
+            payload_layer[i] = layer
+            free_from[a] = free_from[b] = layer + 1
+            after_layer[a] = after_layer[b] = layer
+
+        by_layer: dict[int, list[int]] = defaultdict(list)
+        for i, layer in payload_layer.items():
+            by_layer[layer].append(i)
+        schedule: list[list[int]] = [[i] for i in sorted(gaps[-1])]
+        for layer in range(max(by_layer, default=-1) + 1):
+            if by_layer[layer]:
+                schedule.append(sorted(by_layer[layer]))
+            schedule.extend([i] for i in sorted(gaps[layer]))
+
+        return _emit_layers(circuit, data, indices, set(entanglers), schedule)
+
+
+def _payload_layer_map(circuit: QuantumCircuit) -> dict[tuple[tuple[int, int], int], int]:
+    """``{(edge, occurrence): layer}`` from a circuit whose layers barriers or boxes delimit.
+
+    Keyed by occurrence rather than by position because check insertion may reorder entangling
+    gates that act on disjoint qubits; per-edge order is what survives and is what we need.
+    """
+    layers: dict[tuple[tuple[int, int], int], int] = {}
+    occurrence: Counter = Counter()
+    layer = 0
+    for instruction in circuit.data:
+        name = instruction.operation.name
+        if name == "barrier":
+            layer += 1
+            continue
+        edges = _instruction_edges(instruction, circuit)
+        for edge in edges:
+            layers[(edge, occurrence[edge])] = layer
+            occurrence[edge] += 1
+        if name == "box" and edges:
+            layer += 1
+    ordered = sorted(set(layers.values()))
+    return {key: ordered.index(value) for key, value in layers.items()}
+
+
+def _instruction_edges(instruction, circuit: QuantumCircuit) -> list[tuple[int, int]]:
+    """The qubit pairs an instruction entangles, looking inside it if it is a box."""
+    if instruction.operation.name == "box":
+        body = instruction.operation.blocks[0]
+        qmap = [circuit.find_bit(q).index for q in instruction.qubits]
+        return [
+            (min(pair), max(pair))
+            for sub in body.data
+            if len(sub.qubits) == 2
+            for pair in [[qmap[body.find_bit(q).index] for q in sub.qubits]]
+        ]
+    if len(instruction.qubits) == 2 and instruction.operation.name not in _NOT_PROPAGATED:
+        pair = [circuit.find_bit(q).index for q in instruction.qubits]
+        return [(min(pair), max(pair))]
+    return []
+
+
+def _emit_layers(
+    circuit: QuantumCircuit,
+    data: list,
+    indices: dict[int, list[int]],
+    entanglers: set[int],
+    schedule: list[list[int]],
+) -> QuantumCircuit:
+    """Re-emit ``circuit`` with its entanglers grouped per ``schedule``, barriers between layers.
+
+    Every qubit's instructions keep their original relative order, so the circuit is unchanged.
+    """
+    on_qubit: dict[int, list[int]] = defaultdict(list)
+    for i in range(len(data)):
+        if data[i].operation.name != "barrier":
+            for q in indices[i]:
+                on_qubit[q].append(i)
+
+    cursor: Counter = Counter()
+    emitted: set[int] = set()
+    out = circuit.copy_empty_like()
+
+    def flush_until(qubit: int, target: int) -> None:
+        """Emit everything still pending on ``qubit`` ahead of instruction ``target``."""
+        while on_qubit[qubit][cursor[qubit]] != target:
+            i = on_qubit[qubit][cursor[qubit]]
+            if i not in emitted and i not in entanglers:
+                out.append(data[i])
+                emitted.add(i)
+            cursor[qubit] += 1
+
+    for layer in schedule:
+        for i in layer:
+            for q in indices[i]:
+                flush_until(q, i)
+            out.append(data[i])
+            emitted.add(i)
+            for q in indices[i]:
+                cursor[q] += 1
+        out.barrier()
+    for i in range(len(data)):
+        if i not in emitted and data[i].operation.name != "barrier":
+            out.append(data[i])
+    return out

--- a/python/qiskit_paulice/checked_circuit.py
+++ b/python/qiskit_paulice/checked_circuit.py
@@ -181,7 +181,7 @@ class CheckedCircuit:
     ) -> QuantumCircuit:
         """Box :attr:`circuit` while maintaining concurrent scheduling of payload layers.
 
-        This method delimits the entangling layers of the checked circuit with boxes such
+        This method stratifies the entangling layers of the checked circuit into boxes such
         that the number of unique entangling layers is minimized. This is done by scheduling
         the entangling gates from the Pauli checks into boxes of their own, resulting in one
         unique layer per Pauli check in addition to the ``payload_layers``.

--- a/python/qiskit_paulice/checked_circuit.py
+++ b/python/qiskit_paulice/checked_circuit.py
@@ -14,17 +14,30 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections import defaultdict
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Literal, NamedTuple
+from itertools import groupby
+from typing import Any, Literal, NamedTuple
 
 import numpy as np
 from qiskit import QuantumCircuit
+from samplomatic.transpiler import generate_boxing_pass_manager
 
 from ._internal import Metric as _Metric
 from ._internal.conversion import convert_to_rustiq_circuit as _convert_to_rustiq_circuit
 from ._internal.utils import build_check_picker as _build_check_picker
+
+_NOT_PROPAGATED = frozenset({"measure", "barrier", "delay"})
+_BOXING_DEFAULTS: dict[str, Any] = {
+    "twirling_strategy": "active",
+    "inject_noise_strategy": "individual_modification",
+    "inject_noise_targets": "gates",
+    "inject_noise_site": "after",
+    "measure_annotations": "all",
+    "remove_barriers": "after_stratification",
+}
 
 
 class UncoveredPauli(NamedTuple):
@@ -174,3 +187,129 @@ class CheckedCircuit:
             return (sub_array @ x) % 2
 
         return _aux
+
+    def box(
+        self,
+        payload_layers: Iterable[Iterable[tuple[int, int]]] | None = None,
+        **kwargs,
+    ) -> QuantumCircuit:
+        """Box :attr:`circuit` for samplomatic, with every check gate isolated in its own layer.
+
+        Runs :func:`~samplomatic.transpiler.generate_boxing_pass_manager` on :attr:`circuit` --
+        the circuit that is actually executed, ancillas and check gates included -- after
+        regrouping it so each check gate sits alone in a two-qubit layer scoped to its own
+        qubits. Repeats of a box with the same entangling gates then share a ``ref``: the unique
+        layers a noise learner must characterize are the payload's own plus one small layer per
+        check, a count that does not grow with circuit depth, and the payload boxes carry the
+        same ``ref`` values as a boxing of the bare circuit, so a noise model learned once on the
+        bare circuit binds to them.
+
+        Box the executed circuit, never the bare one: the bare circuit's boxes carry different
+        ``ref`` values while their ``modifier_ref`` values collide with this circuit's. For a
+        depth-preserving boxing without check isolation, run samplomatic's boxing pass on
+        :attr:`circuit` directly.
+
+        Args:
+            payload_layers: the payload's unique entangling layers, each a collection of
+                qubit-index pairs. Supply them when the payload's layer structure is known; every
+                payload stratum is then an instance of exactly one of these layers. An edge may
+                appear in only one layer. When ``None``, layers are derived by packing payload
+                gates as early as possible, which may not recover an intended structure.
+            **kwargs: overrides for :func:`~samplomatic.transpiler.generate_boxing_pass_manager`.
+
+        Returns:
+            :attr:`circuit`, boxed and annotated.
+
+        Raises:
+            ValueError: ``payload_layers`` does not describe this circuit's payload gates, or
+                :attr:`circuit` contains a reset, which is not yet supported.
+        """
+        if any(instruction.operation.name == "reset" for instruction in self.circuit.data):
+            raise ValueError(
+                "circuits containing resets are not supported yet: propagating check "
+                "operators through a reset is not implemented."
+            )
+        options = {**_BOXING_DEFAULTS, **kwargs}
+        return generate_boxing_pass_manager(**options).run(self._stratify(payload_layers))
+
+    def _stratify(
+        self, payload_layers: Iterable[Iterable[tuple[int, int]]] | None
+    ) -> QuantumCircuit:
+        """Re-emit :attr:`circuit` with each check gate alone in its own barrier-delimited layer.
+
+        Every instruction gets a stratum key and the circuit is stable-sorted by it. The keys are
+        monotone along every qubit's wire, so no two instructions sharing a qubit are ever
+        reordered and the result implements the same unitary.
+        """
+        circuit = self.circuit
+        ancillas = set(self.check_qubits)
+        data = [inst for inst in circuit.data if inst.operation.name != "barrier"]
+        indices = [[circuit.find_bit(q).index for q in inst.qubits] for inst in data]
+
+        edge_to_layer = _edge_to_layer(payload_layers) if payload_layers is not None else None
+        stratum_ids: list[int] = []
+        after_layer: dict[int, int] = defaultdict(lambda: -1)
+        checks_in_gap: dict[int, int] = defaultdict(int)
+        free_from: dict[int, int] = defaultdict(int)
+
+        # Payload gates pack as early as their qubits allow; each check gate gets a stratum of
+        # its own, in the gap after the last payload layer to touch its target.
+        keys: dict[int, tuple[int, int, int]] = {}
+        for i, inst in enumerate(data):
+            if len(inst.qubits) != 2 or inst.operation.name in _NOT_PROPAGATED:
+                continue
+            a, b = sorted(indices[i])
+            if {a, b} & ancillas:
+                target = b if a in ancillas else a
+                gap = after_layer[target]
+                checks_in_gap[gap] += 1
+                keys[i] = (gap, 1, checks_in_gap[gap])
+                continue
+            layer = max(free_from[a], free_from[b])
+            if edge_to_layer is not None:
+                if (a, b) not in edge_to_layer:
+                    raise ValueError(
+                        "payload_layers does not describe this circuit's payload gates: edge "
+                        f"{(a, b)} is in no layer."
+                    )
+                # Never mix gates from different unique layers in one stratum.
+                unique = edge_to_layer[(a, b)]
+                while layer < len(stratum_ids) and stratum_ids[layer] != unique:
+                    layer += 1
+                if layer == len(stratum_ids):
+                    stratum_ids.append(unique)
+            keys[i] = (layer, 0, 0)
+            free_from[a] = free_from[b] = layer + 1
+            after_layer[a] = after_layer[b] = layer
+
+        # Every other instruction rides with the next entangler on any of its qubits, or the end.
+        end = (len(data), 0, 0)
+        next_key: dict[int, tuple[int, int, int]] = defaultdict(lambda: end)
+        for i in reversed(range(len(data))):
+            if i in keys:
+                for q in indices[i]:
+                    next_key[q] = keys[i]
+            else:
+                keys[i] = min((next_key[q] for q in indices[i]), default=end)
+
+        out = circuit.copy_empty_like()
+        order = sorted(range(len(data)), key=keys.__getitem__)
+        for key, stratum in groupby(order, key=keys.__getitem__):
+            for i in stratum:
+                out.append(data[i])
+            if key != end:
+                out.barrier()
+        return out
+
+
+def _edge_to_layer(
+    payload_layers: Iterable[Iterable[tuple[int, int]]],
+) -> dict[tuple[int, int], int]:
+    """Map each entangling edge to the index of the unique payload layer containing it."""
+    edge_to_layer: dict[tuple[int, int], int] = {}
+    for index, layer in enumerate(payload_layers):
+        for a, b in layer:
+            edge = (min(a, b), max(a, b))
+            if edge_to_layer.setdefault(edge, index) != index:
+                raise ValueError(f"edge {edge} appears in more than one payload layer.")
+    return edge_to_layer

--- a/python/qiskit_paulice/checked_circuit.py
+++ b/python/qiskit_paulice/checked_circuit.py
@@ -181,11 +181,14 @@ class CheckedCircuit:
     ) -> QuantumCircuit:
         """Box :attr:`circuit` while maintaining concurrent scheduling of payload layers.
 
-        This method schedules each entangling gate connecting a target, ancilla pair of
-        qubits into its own box. This is beneficial in that the number of unique entangling
-        layers is minimized, but it comes at a cost of sub-optimal scheduling since scheduling
-        each gate of each Pauli check into its own time slice causes additional idling time across
-        all qubits.
+        This method delimits the entangling layers of the checked circuit with boxes such
+        that the number of unique entangling layers is minimized. This is done by scheduling
+        the entangling gates from the Pauli checks into boxes of their own, resulting in one
+        unique layer per Pauli check in addition to the ``payload_layers``.
+
+        Scheduling check gates into boxes of their own is beneficial in that the number of
+        unique entangling layers is minimized, but it comes at a cost of sub-optimal
+        gate scheduling.
 
         Args:
             payload_layers: The unique entangling layers of the bare payload circuit. Each inner

--- a/releasenotes/notes/box-checked-circuit-8c1d2e4f5a6b7c90.yaml
+++ b/releasenotes/notes/box-checked-circuit-8c1d2e4f5a6b7c90.yaml
@@ -2,10 +2,9 @@
 features:
   - |
     Added :meth:`qiskit_paulice.CheckedCircuit.box`, which groups the checked circuit into the
-    annotated boxes ``samplomatic`` uses for twirling, noise learning, and sampling, giving
-    every check gate a two-qubit layer of its own. Repeated boxes with the same entangling
-    gates share box references, so the number of unique layers to learn stays flat in circuit
-    depth, and a noise model learned on the bare circuit binds to the payload boxes.
+    annotated boxes used for twirling, noise learning, and sampling, scheduling
+    each Pauli check entangling gate into a box of its own. This minimizes the number of unique entangling
+    layers at the cost of sub-optimal gate scheduling.
 upgrade:
   - |
     ``qiskit-paulice`` now requires ``samplomatic>=0.20.0``.

--- a/releasenotes/notes/box-checked-circuit-8c1d2e4f5a6b7c90.yaml
+++ b/releasenotes/notes/box-checked-circuit-8c1d2e4f5a6b7c90.yaml
@@ -5,6 +5,3 @@ features:
     annotated boxes used for twirling, noise learning, and sampling, scheduling
     each Pauli check entangling gate into a box of its own. This minimizes the number of unique entangling
     layers at the cost of sub-optimal gate scheduling.
-upgrade:
-  - |
-    ``qiskit-paulice`` now requires ``samplomatic>=0.20.0``.

--- a/releasenotes/notes/box-checked-circuit-8c1d2e4f5a6b7c90.yaml
+++ b/releasenotes/notes/box-checked-circuit-8c1d2e4f5a6b7c90.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Added :meth:`qiskit_paulice.CheckedCircuit.box`, which groups the checked circuit into
+    the annotated boxes ``samplomatic`` uses for twirling, noise learning, and sampling. The
+    default ``check_layers="isolated"`` gives every check gate its own two-qubit layer, keeping
+    the number of unique layers to learn flat in circuit depth; ``check_layers="merged"`` packs
+    check gates into the payload layers instead, trading learning cost for depth and full
+    idling-noise coverage.
+upgrade:
+  - |
+    ``qiskit-paulice`` now requires ``samplomatic>=0.20.0``.

--- a/releasenotes/notes/box-checked-circuit-8c1d2e4f5a6b7c90.yaml
+++ b/releasenotes/notes/box-checked-circuit-8c1d2e4f5a6b7c90.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Added :meth:`qiskit_paulice.CheckedCircuit.box`, which groups the checked circuit into the
+    annotated boxes ``samplomatic`` uses for twirling, noise learning, and sampling, giving
+    every check gate a two-qubit layer of its own. Repeated boxes with the same entangling
+    gates share box references, so the number of unique layers to learn stays flat in circuit
+    depth, and a noise model learned on the bare circuit binds to the payload boxes.
+upgrade:
+  - |
+    ``qiskit-paulice`` now requires ``samplomatic>=0.20.0``.

--- a/test/test_box.py
+++ b/test/test_box.py
@@ -1,0 +1,260 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for ``CheckedCircuit.box``."""
+
+from __future__ import annotations
+
+import unittest
+import warnings
+from collections import Counter
+
+import samplomatic
+from qiskit import QuantumCircuit
+from qiskit.quantum_info import Clifford
+from qiskit.transpiler.passes import RemoveBarriers
+from qiskit_paulice import add_pauli_checks
+from qiskit_paulice.checked_circuit import (
+    _BOXING_DEFAULTS,
+    _ISOLATED_BOXING_DEFAULTS,
+)
+from qiskit_paulice.noise_models import NoiseModel
+from samplomatic.annotations import InjectNoise
+from samplomatic.transpiler import generate_boxing_pass_manager
+from samplomatic.utils import get_annotation
+
+
+def _bare_circuit(nq=4, depth=4, barriers=False):
+    """A brickwork Clifford payload, optionally with its layer boundaries marked."""
+    qc = QuantumCircuit(nq)
+    qc.h(range(nq))
+    for d in range(depth):
+        for i in range(d % 2, nq - 1, 2):
+            qc.cz(i, i + 1)
+        for q in range(nq):
+            qc.sx(q)
+        if barriers:
+            qc.barrier()
+    qc.measure_all()
+    return qc
+
+
+def _gate_counts(circuit):
+    """Gate tallies, ignoring the barriers that mark layer boundaries."""
+    return Counter(inst.operation.name for inst in circuit.data if inst.operation.name != "barrier")
+
+
+def _box_edges(instruction, boxed):
+    """The entangled qubit pairs inside one box."""
+    body = instruction.operation.blocks[0]
+    qmap = [boxed.find_bit(q).index for q in instruction.qubits]
+    return [
+        tuple(sorted(qmap[body.find_bit(q).index] for q in sub.qubits))
+        for sub in body.data
+        if len(sub.qubits) == 2
+    ]
+
+
+def _box_edge_sets(boxed):
+    """The set of entangled qubit pairs inside each box, in circuit order."""
+    out = []
+    for instruction in boxed.data:
+        if instruction.operation.name != "box":
+            continue
+        edges = frozenset(_box_edges(instruction, boxed))
+        if edges:
+            out.append(edges)
+    return out
+
+
+def _checked_example(nq=4, depth=4, seed=1):
+    """A ``CheckedCircuit`` and its boxed form."""
+    qc = _bare_circuit(nq, depth)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        checked = add_pauli_checks(
+            qc, list(range(nq)), NoiseModel(gate_noise=1e-3, readout_noise=1e-2), seed=seed
+        )[-1]
+        boxed = checked.box()
+    return checked, boxed
+
+
+class TestBox(unittest.TestCase):
+    """Tests for ``CheckedCircuit.box``."""
+
+    def test_boxes_the_executed_circuit(self):
+        """Every entangling gate of the checked circuit -- check gates included -- lands in a box."""
+        checked, boxed = _checked_example()
+        ancillas = set(checked.check_qubits)
+        circuit_edges = [
+            tuple(sorted(checked.circuit.find_bit(q).index for q in inst.qubits))
+            for inst in checked.circuit.data
+            if len(inst.qubits) == 2
+        ]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            merged = checked.box(check_layers="merged")
+        for layout, circ in [("isolated", boxed), ("merged", merged)]:
+            with self.subTest(layout):
+                boxed_edges = [
+                    edge
+                    for instruction in circ.data
+                    if instruction.operation.name == "box"
+                    for edge in _box_edges(instruction, circ)
+                ]
+                self.assertEqual(sorted(boxed_edges), sorted(circuit_edges))
+                # the check gates are really in there
+                self.assertTrue(any(set(e) & ancillas for e in boxed_edges))
+
+    def test_rejects_resets(self):
+        """Resets alter the Heisenberg evolution and are rejected until supported."""
+        checked, _ = _checked_example()
+        checked.circuit.reset(0)
+        with self.assertRaises(ValueError):
+            checked.box()
+
+    def test_rejects_unknown_check_layers(self):
+        """A typo'd strategy is an error, not a silent fallback."""
+        checked, _ = _checked_example()
+        with self.assertRaises(ValueError):
+            checked.box(check_layers="seperate")
+
+
+class TestIsolatedCheckLayers(unittest.TestCase):
+    """Tests for ``CheckedCircuit.box(check_layers="isolated")``."""
+
+    def setUp(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.checked, _ = _checked_example(nq=6, depth=8, seed=4)
+            self.isolated = self.checked.box(check_layers="isolated")
+
+    def test_same_circuit(self):
+        """Isolating check gates only regroups them: same gates, same unitary."""
+        stripped = self.checked._stratify(None)
+        self.assertEqual(_gate_counts(self.checked.circuit), _gate_counts(stripped))
+        original = RemoveBarriers()(self.checked.circuit.remove_final_measurements(inplace=False))
+        restratified = RemoveBarriers()(stripped.remove_final_measurements(inplace=False))
+        self.assertEqual(Clifford(original), Clifford(restratified))
+
+    def test_each_check_gate_boxed_alone(self):
+        """No box mixes a check gate with anything else."""
+        ancillas = set(self.checked.check_qubits)
+        saw_check_box = False
+        for edges in _box_edge_sets(self.isolated):
+            if any(set(e) & ancillas for e in edges):
+                self.assertEqual(len(edges), 1)
+                saw_check_box = True
+        self.assertTrue(saw_check_box)
+
+    def test_unique_layers_is_payload_plus_one_per_check(self):
+        """The whole point: check layers contribute exactly one unique layer each."""
+        ancillas = set(self.checked.check_qubits)
+        payload, check = set(), set()
+        for edges in _box_edge_sets(self.isolated):
+            (check if any(set(e) & ancillas for e in edges) else payload).add(edges)
+        self.assertEqual(len(check), len(self.checked.check_support))
+        # ... and every check's single-gate layer recurs rather than proliferating
+        self.assertLess(len(check) + len(payload), sum(1 for _ in _box_edge_sets(self.isolated)))
+
+    def test_preserves_authored_payload_layers(self):
+        """Given the bare circuit's layer boundaries, the payload's own layers come back exactly."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            bare = _bare_circuit(nq=6, depth=8, barriers=True)
+            checked = add_pauli_checks(
+                RemoveBarriers()(bare),
+                list(range(6)),
+                NoiseModel(gate_noise=1e-3, readout_noise=1e-2),
+                seed=4,
+            )[-1]
+            isolated = checked.box(check_layers="isolated", payload_layers=bare)
+        ancillas = set(checked.check_qubits)
+        payload = {
+            edges for edges in _box_edge_sets(isolated) if not any(set(e) & ancillas for e in edges)
+        }
+        # the brickwork payload has exactly two distinct entangling layers
+        self.assertEqual(len(payload), 2)
+
+    def test_rejects_foreign_payload_layers(self):
+        """Layer boundaries from a different circuit are an error, not a mislabelling."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            other = _bare_circuit(nq=6, depth=2, barriers=True)
+        with self.assertRaises(ValueError):
+            self.checked.box(check_layers="isolated", payload_layers=other)
+
+    def test_builds_a_samplex(self):
+        """The isolated boxing is a working samplomatic circuit."""
+        samplomatic.build(self.isolated)
+
+
+class TestBareModelReuse(unittest.TestCase):
+    """A model learned once on the bare circuit binds to the checked circuit's payload boxes."""
+
+    def setUp(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.bare = _bare_circuit(nq=6, depth=8, barriers=True)
+            self.checked = add_pauli_checks(
+                RemoveBarriers()(self.bare),
+                list(range(6)),
+                NoiseModel(gate_noise=1e-3, readout_noise=1e-2),
+                seed=4,
+            )[-1]
+            self.isolated = self.checked.box(check_layers="isolated", payload_layers=self.bare)
+            # the bare circuit boxed exactly as the checked circuit's payload boxes are
+            self.boxed_bare = generate_boxing_pass_manager(
+                **{**_BOXING_DEFAULTS, **_ISOLATED_BOXING_DEFAULTS}
+            ).run(self.bare)
+
+    def test_payload_refs_come_from_the_bare_circuit(self):
+        """Every payload box carries a ref the bare circuit's boxing also carries."""
+        bare_refs = {
+            inject.ref
+            for instruction in self.boxed_bare.data
+            if instruction.operation.name == "box"
+            and (inject := get_annotation(instruction.operation, InjectNoise)) is not None
+            and inject.ref
+        }
+        ancillas = set(self.checked.check_qubits)
+        payload_refs, check_refs = set(), set()
+        for instruction in self.isolated.data:
+            if instruction.operation.name != "box":
+                continue
+            inject = get_annotation(instruction.operation, InjectNoise)
+            edges = _box_edges(instruction, self.isolated)
+            if inject is None or not edges:
+                continue
+            target = check_refs if any(set(e) & ancillas for e in edges) else payload_refs
+            target.add(inject.ref)
+        self.assertTrue(payload_refs)
+        self.assertLessEqual(payload_refs, bare_refs)
+        # the check layers are the only thing the bare model does not cover
+        self.assertFalse(check_refs & bare_refs)
+        # a brickwork payload keeps its two layers, and each check contributes one small layer
+        self.assertEqual(len(payload_refs), 2)
+        self.assertEqual(len(check_refs), len(self.checked.check_support))
+
+    def test_check_layers_are_two_qubit_models(self):
+        """Isolated check layers are cheap to characterize, not full-width."""
+        ancillas = set(self.checked.check_qubits)
+        for instruction in self.isolated.data:
+            if instruction.operation.name != "box":
+                continue
+            edges = _box_edges(instruction, self.isolated)
+            if edges and any(set(e) & ancillas for e in edges):
+                self.assertEqual(len(instruction.qubits), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_checked_circuit.py
+++ b/test/test_checked_circuit.py
@@ -24,7 +24,7 @@ from qiskit import QuantumCircuit
 from qiskit.quantum_info import Clifford
 from qiskit.transpiler.passes import RemoveBarriers
 from qiskit_paulice import CheckedCircuit, UncoveredPauli, add_pauli_checks
-from qiskit_paulice.checked_circuit import _BOXING_DEFAULTS
+from qiskit_paulice.checked_circuit import BOXING_DEFAULTS
 from qiskit_paulice.noise_models import NoiseModel
 from samplomatic.annotations import InjectNoise
 from samplomatic.transpiler import generate_boxing_pass_manager
@@ -229,11 +229,15 @@ class TestBox(unittest.TestCase):
         # the check gates are really in there
         self.assertTrue(any(set(e) & ancillas for e in boxed_edges))
 
-    def test_rejects_resets(self):
-        """Resets alter the Heisenberg evolution and are rejected until supported."""
+    def test_rejects_non_gate_instructions(self):
+        """Anything but unitary gates, measures, and barriers is rejected.
+
+        Resets alter the check propagation, and control flow can be reordered by
+        stratification, which tracks qubit wires but not clbit dataflow.
+        """
         checked, _ = _checked_example()
         checked.circuit.reset(0)
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "reset"):
             checked.box()
 
 
@@ -323,7 +327,7 @@ class TestBareModelReuse(unittest.TestCase):
             )[-1]
             self.isolated = self.checked.box(payload_layers=_brickwork_layers(6))
             # the bare circuit boxed exactly as the checked circuit's payload boxes are
-            self.boxed_bare = generate_boxing_pass_manager(**_BOXING_DEFAULTS).run(self.bare)
+            self.boxed_bare = generate_boxing_pass_manager(**BOXING_DEFAULTS).run(self.bare)
 
     def test_payload_refs_come_from_the_bare_circuit(self):
         """Every payload box carries a ref the bare circuit's boxing also carries."""

--- a/test/test_checked_circuit.py
+++ b/test/test_checked_circuit.py
@@ -303,12 +303,19 @@ class TestIsolatedCheckLayers(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.checked.box(payload_layers=_brickwork_layers(4))
 
-    def test_rejects_ambiguous_payload_layers(self):
-        """Error on redundant layers."""
-        layers = _brickwork_layers(6)
-        layers[1].add((0, 1))
-        with self.assertRaises(ValueError):
-            self.checked.box(payload_layers=layers)
+    def test_shared_edges_across_payload_layers(self):
+        """An edge may sit in several unique layers; each stratum instantiates one of them."""
+        qc = QuantumCircuit(4)
+        qc.cz(0, 1)
+        qc.cz(2, 3)
+        qc.cz(1, 2)
+        qc.cz(2, 3)
+        qc.measure_all()
+        checked = CheckedCircuit(circuit=qc)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            boxed = checked.box(payload_layers=[{(0, 1), (2, 3)}, {(1, 2)}, {(2, 3)}])
+        self.assertEqual(_box_edge_sets(boxed), [{(0, 1), (2, 3)}, {(1, 2)}, {(2, 3)}])
 
     def test_builds_a_samplex(self):
         """The boxed circuit is a working samplomatic circuit."""

--- a/test/test_checked_circuit.py
+++ b/test/test_checked_circuit.py
@@ -15,10 +15,20 @@
 from __future__ import annotations
 
 import unittest
+import warnings
+from collections import Counter
 
 import numpy as np
+import samplomatic
 from qiskit import QuantumCircuit
-from qiskit_paulice import CheckedCircuit, UncoveredPauli
+from qiskit.quantum_info import Clifford
+from qiskit.transpiler.passes import RemoveBarriers
+from qiskit_paulice import CheckedCircuit, UncoveredPauli, add_pauli_checks
+from qiskit_paulice.checked_circuit import _BOXING_DEFAULTS
+from qiskit_paulice.noise_models import NoiseModel
+from samplomatic.annotations import InjectNoise
+from samplomatic.transpiler import generate_boxing_pass_manager
+from samplomatic.utils import get_annotation
 
 
 def _bell_with_measure() -> QuantumCircuit:
@@ -28,6 +38,66 @@ def _bell_with_measure() -> QuantumCircuit:
     qc.measure(0, 0)
     qc.measure(1, 1)
     return qc
+
+
+def _bare_circuit(nq=4, depth=4, barriers=False):
+    """A brickwork Clifford payload, optionally with its layer boundaries marked."""
+    qc = QuantumCircuit(nq)
+    qc.h(range(nq))
+    for d in range(depth):
+        for i in range(d % 2, nq - 1, 2):
+            qc.cz(i, i + 1)
+        for q in range(nq):
+            qc.sx(q)
+        if barriers:
+            qc.barrier()
+    qc.measure_all()
+    return qc
+
+
+def _brickwork_layers(nq):
+    """The two unique entangling layers of the brickwork payload."""
+    return [{(i, i + 1) for i in range(0, nq - 1, 2)}, {(i, i + 1) for i in range(1, nq - 1, 2)}]
+
+
+def _gate_counts(circuit):
+    """Gate tallies, ignoring the barriers that mark layer boundaries."""
+    return Counter(inst.operation.name for inst in circuit.data if inst.operation.name != "barrier")
+
+
+def _box_edges(instruction, boxed):
+    """The entangled qubit pairs inside one box."""
+    body = instruction.operation.blocks[0]
+    qmap = [boxed.find_bit(q).index for q in instruction.qubits]
+    return [
+        tuple(sorted(qmap[body.find_bit(q).index] for q in sub.qubits))
+        for sub in body.data
+        if len(sub.qubits) == 2
+    ]
+
+
+def _box_edge_sets(boxed):
+    """The set of entangled qubit pairs inside each box, in circuit order."""
+    out = []
+    for instruction in boxed.data:
+        if instruction.operation.name != "box":
+            continue
+        edges = frozenset(_box_edges(instruction, boxed))
+        if edges:
+            out.append(edges)
+    return out
+
+
+def _checked_example(nq=4, depth=4, seed=1):
+    """A ``CheckedCircuit`` and its boxed form."""
+    qc = _bare_circuit(nq, depth)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        checked = add_pauli_checks(
+            qc, list(range(nq)), NoiseModel(gate_noise=1e-3, readout_noise=1e-2), seed=seed
+        )[-1]
+        boxed = checked.box()
+    return checked, boxed
 
 
 class TestCheckedCircuit(unittest.TestCase):
@@ -135,3 +205,150 @@ class TestCheckedCircuit(unittest.TestCase):
         f = cc.get_postselection_method()
         np.testing.assert_array_equal(f("10"), np.array([1]))
         np.testing.assert_array_equal(f("11"), np.array([0]))
+
+
+class TestBox(unittest.TestCase):
+    """Tests for ``CheckedCircuit.box``."""
+
+    def test_boxes_the_executed_circuit(self):
+        """Every entangling gate of the checked circuit -- check gates included -- lands in a box."""
+        checked, boxed = _checked_example()
+        ancillas = set(checked.check_qubits)
+        circuit_edges = [
+            tuple(sorted(checked.circuit.find_bit(q).index for q in inst.qubits))
+            for inst in checked.circuit.data
+            if len(inst.qubits) == 2
+        ]
+        boxed_edges = [
+            edge
+            for instruction in boxed.data
+            if instruction.operation.name == "box"
+            for edge in _box_edges(instruction, boxed)
+        ]
+        self.assertEqual(sorted(boxed_edges), sorted(circuit_edges))
+        # the check gates are really in there
+        self.assertTrue(any(set(e) & ancillas for e in boxed_edges))
+
+    def test_rejects_resets(self):
+        """Resets alter the Heisenberg evolution and are rejected until supported."""
+        checked, _ = _checked_example()
+        checked.circuit.reset(0)
+        with self.assertRaises(ValueError):
+            checked.box()
+
+
+class TestIsolatedCheckLayers(unittest.TestCase):
+    """Tests for the isolated check layers ``CheckedCircuit.box`` produces."""
+
+    def setUp(self):
+        self.checked, self.isolated = _checked_example(nq=6, depth=8, seed=4)
+
+    def test_same_circuit(self):
+        """Isolating check gates only regroups them: same gates, same unitary."""
+        stripped = self.checked._stratify(None)
+        self.assertEqual(_gate_counts(self.checked.circuit), _gate_counts(stripped))
+        original = RemoveBarriers()(self.checked.circuit.remove_final_measurements(inplace=False))
+        restratified = RemoveBarriers()(stripped.remove_final_measurements(inplace=False))
+        self.assertEqual(Clifford(original), Clifford(restratified))
+
+    def test_each_check_gate_boxed_alone(self):
+        """A check box is exactly its one gate: a single edge on a two-qubit box."""
+        ancillas = set(self.checked.check_qubits)
+        saw_check_box = False
+        for instruction in self.isolated.data:
+            if instruction.operation.name != "box":
+                continue
+            edges = _box_edges(instruction, self.isolated)
+            if any(set(e) & ancillas for e in edges):
+                self.assertEqual(len(edges), 1)
+                self.assertEqual(len(instruction.qubits), 2)
+                saw_check_box = True
+        self.assertTrue(saw_check_box)
+
+    def test_unique_layers_is_payload_plus_one_per_check(self):
+        """The whole point: two brickwork payload layers plus one unique layer per check."""
+        ancillas = set(self.checked.check_qubits)
+        payload, check = set(), set()
+        for edges in _box_edge_sets(self.isolated):
+            (check if any(set(e) & ancillas for e in edges) else payload).add(edges)
+        self.assertEqual(len(payload), 2)
+        self.assertEqual(len(check), len(self.checked.check_support))
+        # ... and every layer recurs rather than proliferating
+        self.assertLess(len(check) + len(payload), sum(1 for _ in _box_edge_sets(self.isolated)))
+
+    def test_payload_layers_split_what_packing_would_merge(self):
+        """The palette is authoritative: gates that packing would share a stratum get split."""
+        qc = QuantumCircuit(4)
+        qc.cz(0, 1)
+        qc.cz(2, 3)
+        qc.measure_all()
+        checked = CheckedCircuit(circuit=qc)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            packed = checked.box()
+            # the reversed edge also checks pair normalization
+            split = checked.box(payload_layers=[{(1, 0)}, {(2, 3)}])
+        self.assertEqual(len(set(_box_edge_sets(packed))), 1)
+        self.assertEqual(len(set(_box_edge_sets(split))), 2)
+
+    def test_rejects_foreign_payload_layers(self):
+        """Layers that do not cover the payload's edges are an error, not a mislabelling."""
+        with self.assertRaises(ValueError):
+            self.checked.box(payload_layers=_brickwork_layers(4))
+
+    def test_rejects_ambiguous_payload_layers(self):
+        """An edge sitting in two unique layers has no well-defined boxing."""
+        layers = _brickwork_layers(6)
+        layers[1].add((0, 1))
+        with self.assertRaises(ValueError):
+            self.checked.box(payload_layers=layers)
+
+    def test_builds_a_samplex(self):
+        """The isolated boxing is a working samplomatic circuit."""
+        samplomatic.build(self.isolated)
+
+
+class TestBareModelReuse(unittest.TestCase):
+    """A model learned once on the bare circuit binds to the checked circuit's payload boxes."""
+
+    def setUp(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.bare = _bare_circuit(nq=6, depth=8, barriers=True)
+            self.checked = add_pauli_checks(
+                RemoveBarriers()(self.bare),
+                list(range(6)),
+                NoiseModel(gate_noise=1e-3, readout_noise=1e-2),
+                seed=4,
+            )[-1]
+            self.isolated = self.checked.box(payload_layers=_brickwork_layers(6))
+            # the bare circuit boxed exactly as the checked circuit's payload boxes are
+            self.boxed_bare = generate_boxing_pass_manager(**_BOXING_DEFAULTS).run(self.bare)
+
+    def test_payload_refs_come_from_the_bare_circuit(self):
+        """Every payload box carries a ref the bare circuit's boxing also carries."""
+        bare_refs = {
+            inject.ref
+            for instruction in self.boxed_bare.data
+            if instruction.operation.name == "box"
+            and (inject := get_annotation(instruction.operation, InjectNoise)) is not None
+            and inject.ref
+        }
+        ancillas = set(self.checked.check_qubits)
+        payload_refs, check_refs = set(), set()
+        for instruction in self.isolated.data:
+            if instruction.operation.name != "box":
+                continue
+            inject = get_annotation(instruction.operation, InjectNoise)
+            edges = _box_edges(instruction, self.isolated)
+            if inject is None or not edges:
+                continue
+            target = check_refs if any(set(e) & ancillas for e in edges) else payload_refs
+            target.add(inject.ref)
+        self.assertTrue(payload_refs)
+        self.assertLessEqual(payload_refs, bare_refs)
+        # the check layers are the only thing the bare model does not cover
+        self.assertFalse(check_refs & bare_refs)
+        # a brickwork payload keeps its two layers, and each check contributes one small layer
+        self.assertEqual(len(payload_refs), 2)
+        self.assertEqual(len(check_refs), len(self.checked.check_support))

--- a/test/test_checked_circuit.py
+++ b/test/test_checked_circuit.py
@@ -211,7 +211,7 @@ class TestBox(unittest.TestCase):
     """Tests for ``CheckedCircuit.box``."""
 
     def test_boxes_the_executed_circuit(self):
-        """Every entangling gate of the checked circuit -- check gates included -- lands in a box."""
+        """Every entangling gate of the checked circuit lands in a box."""
         checked, boxed = _checked_example()
         ancillas = set(checked.check_qubits)
         circuit_edges = [
@@ -229,12 +229,15 @@ class TestBox(unittest.TestCase):
         # the check gates are really in there
         self.assertTrue(any(set(e) & ancillas for e in boxed_edges))
 
-    def test_rejects_non_gate_instructions(self):
-        """Anything but unitary gates, measures, and barriers is rejected.
+    def test_rejects_gates_on_three_or_more_qubits(self):
+        """A many-qubit gate is an error: stratification would silently reorder it."""
+        checked, _ = _checked_example()
+        checked.circuit.ccx(0, 1, 2)
+        with self.assertRaisesRegex(ValueError, "ccx"):
+            checked.box()
 
-        Resets alter the check propagation, and control flow can be reordered by
-        stratification, which tracks qubit wires but not clbit dataflow.
-        """
+    def test_rejects_non_gate_instructions(self):
+        """Anything but unitary gates, measures, and barriers is rejected."""
         checked, _ = _checked_example()
         checked.circuit.reset(0)
         with self.assertRaisesRegex(ValueError, "reset"):
@@ -248,7 +251,7 @@ class TestIsolatedCheckLayers(unittest.TestCase):
         self.checked, self.isolated = _checked_example(nq=6, depth=8, seed=4)
 
     def test_same_circuit(self):
-        """Isolating check gates only regroups them: same gates, same unitary."""
+        """Isolating check gates doesn't change the unitary the circuit implements."""
         stripped = self.checked._stratify(None)
         self.assertEqual(_gate_counts(self.checked.circuit), _gate_counts(stripped))
         original = RemoveBarriers()(self.checked.circuit.remove_final_measurements(inplace=False))
@@ -256,7 +259,7 @@ class TestIsolatedCheckLayers(unittest.TestCase):
         self.assertEqual(Clifford(original), Clifford(restratified))
 
     def test_each_check_gate_boxed_alone(self):
-        """A check box is exactly its one gate: a single edge on a two-qubit box."""
+        """A check box is exactly its one gate."""
         ancillas = set(self.checked.check_qubits)
         saw_check_box = False
         for instruction in self.isolated.data:
@@ -270,7 +273,7 @@ class TestIsolatedCheckLayers(unittest.TestCase):
         self.assertTrue(saw_check_box)
 
     def test_unique_layers_is_payload_plus_one_per_check(self):
-        """The whole point: two brickwork payload layers plus one unique layer per check."""
+        """Ensure checks add one unique layer apiece."""
         ancillas = set(self.checked.check_qubits)
         payload, check = set(), set()
         for edges in _box_edge_sets(self.isolated):
@@ -296,19 +299,19 @@ class TestIsolatedCheckLayers(unittest.TestCase):
         self.assertEqual(len(set(_box_edge_sets(split))), 2)
 
     def test_rejects_foreign_payload_layers(self):
-        """Layers that do not cover the payload's edges are an error, not a mislabelling."""
+        """Error on layers that do not cover the payload's edges."""
         with self.assertRaises(ValueError):
             self.checked.box(payload_layers=_brickwork_layers(4))
 
     def test_rejects_ambiguous_payload_layers(self):
-        """An edge sitting in two unique layers has no well-defined boxing."""
+        """Error on redundant layers."""
         layers = _brickwork_layers(6)
         layers[1].add((0, 1))
         with self.assertRaises(ValueError):
             self.checked.box(payload_layers=layers)
 
     def test_builds_a_samplex(self):
-        """The isolated boxing is a working samplomatic circuit."""
+        """The boxed circuit is a working samplomatic circuit."""
         samplomatic.build(self.isolated)
 
 


### PR DESCRIPTION
Add a method, ``box`` to ``CheckedCircuit`` that stratifies entangling layers in boxes such that the number of unique entangling layers is minimized. This is done by scheduling each entangling gate from each Pauli check in a box of its own. This has the benefit of preserving hardware-efficient layers on the bare circuit, so the number of unique layers increases by only 1 for each additional check. The downside is that the gates are now scheduled sub-optimally, resulting in additional idling time on all qubits.